### PR TITLE
Treat conns passed to HydrateConnections as a target

### DIFF
--- a/dbresolver.go
+++ b/dbresolver.go
@@ -299,12 +299,20 @@ func (dr *DBResolver) HydrateConnections(conns, workers int) error {
 	globalResolver := dr.global
 	for _, s := range globalResolver.sources {
 		if db, ok := s.ConnPool.(*sql.DB); ok {
-			hydrateConnections(db, conns, workers)
+			diff := conns - db.Stats().OpenConnections
+			log.Printf("diff source: %d", diff)
+			if diff > 0 {
+				hydrateConnections(db, diff+1, workers)
+			}
 		}
 	}
 	for _, r := range globalResolver.replicas {
 		if db, ok := r.ConnPool.(*sql.DB); ok {
-			hydrateConnections(db, conns, workers)
+			diff := conns - db.Stats().OpenConnections
+			log.Printf("diff replica: %d", diff)
+			if diff > 0 {
+				hydrateConnections(db, diff+1, workers)
+			}
 		}
 	}
 	return nil

--- a/dbresolver.go
+++ b/dbresolver.go
@@ -302,7 +302,7 @@ func (dr *DBResolver) HydrateConnections(conns, workers int) (int, error) {
 	globalResolver := dr.global
 	for _, s := range globalResolver.sources {
 		if db, ok := s.ConnPool.(*sql.DB); ok {
-			diff := conns - db.Stats().OpenConnections
+			diff := conns - db.Stats().OpenConnections + 1
 			if diff <= 0 {
 				continue
 			}
@@ -315,7 +315,7 @@ func (dr *DBResolver) HydrateConnections(conns, workers int) (int, error) {
 
 	for _, r := range globalResolver.replicas {
 		if db, ok := r.ConnPool.(*sql.DB); ok {
-			diff := conns - db.Stats().OpenConnections
+			diff := conns - db.Stats().OpenConnections + 1
 			if diff <= 0 {
 				continue
 			}

--- a/dbresolver.go
+++ b/dbresolver.go
@@ -300,11 +300,11 @@ func (dr *DBResolver) HydrateConnections(conns, workers int) (int, error) {
 	globalResolver := dr.global
 	for _, s := range globalResolver.sources {
 		if db, ok := s.ConnPool.(*sql.DB); ok {
-			diff := conns - db.Stats().OpenConnections
+			diff := conns - db.Stats().OpenConnections + 1
 			if diff <= 0 {
 				continue
 			}
-			err := hydrateConnections(db, diff+1, workers)
+			err := hydrateConnections(db, diff, workers)
 			if err != nil {
 				return opened, err
 			}
@@ -314,11 +314,11 @@ func (dr *DBResolver) HydrateConnections(conns, workers int) (int, error) {
 
 	for _, r := range globalResolver.replicas {
 		if db, ok := r.ConnPool.(*sql.DB); ok {
-			diff := conns - db.Stats().OpenConnections
+			diff := conns - db.Stats().OpenConnections + 1
 			if diff <= 0 {
 				continue
 			}
-			err := hydrateConnections(db, diff+1, workers)
+			err := hydrateConnections(db, diff, workers)
 			if err != nil {
 				return opened, err
 			}

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module gorm.io/plugin/dbresolver
 go 1.14
 
 require (
+	golang.org/x/sync v0.7.0 // indirect
 	gorm.io/driver/mysql v1.4.3
 	gorm.io/gorm v1.24.3
 )

--- a/go.sum
+++ b/go.sum
@@ -5,6 +5,8 @@ github.com/jinzhu/inflection v1.0.0/go.mod h1:h+uFLlag+Qp1Va5pdKtLDYj+kHp5pxUVkr
 github.com/jinzhu/now v1.1.4/go.mod h1:d3SSVoowX0Lcu0IBviAWJpolVfI5UJVZZ7cO71lE/z8=
 github.com/jinzhu/now v1.1.5 h1:/o9tlHleP7gOFmsnYNz3RGnqzefHA47wQpKrrdTIwXQ=
 github.com/jinzhu/now v1.1.5/go.mod h1:d3SSVoowX0Lcu0IBviAWJpolVfI5UJVZZ7cO71lE/z8=
+golang.org/x/sync v0.7.0 h1:YsImfSBoP9QPYL0xyKJPq0gcaJdG3rInoqxTWbfQu9M=
+golang.org/x/sync v0.7.0/go.mod h1:Czt+wKu1gCyEFDUtn0jG5QVvpJ6rzVqr5aXyt9drQfk=
 gorm.io/driver/mysql v1.4.3 h1:/JhWJhO2v17d8hjApTltKNADm7K7YI2ogkR7avJUL3k=
 gorm.io/driver/mysql v1.4.3/go.mod h1:sSIebwZAVPiT+27jK9HIwvsqOGKx3YMPmrA3mBJR10c=
 gorm.io/gorm v1.23.8/go.mod h1:l2lP/RyAtc1ynaTjFksBde/O8v9oOGIApu2/xRitmZk=


### PR DESCRIPTION
Modifies `HydrateConnections` to calculate the number of connections it should open based on  how many `OpenConnections` already exist across each instance